### PR TITLE
Fix typo in README: main.yy to main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install the "psutil" library and Python.
 Open terminal in the project directory and run main.py
 
 ```bash
-  python main.yy
+  python main.py
 ```
 
 ## Commands


### PR DESCRIPTION
Fixed a typo in the README where main.yy was incorrectly listed instead of main.py